### PR TITLE
Allow FilterLenses to accept regex arguments

### DIFF
--- a/src/array/FilterLens.js
+++ b/src/array/FilterLens.js
@@ -15,8 +15,16 @@ var _ = require('lodash'),
  */
 get = function (filter) {
     return function (arr) {
-        // Return only the elements that are truthy from the filter function
-        return _.filter(arr, filter);
+        if (_.isFunction(filter)) {
+            // Return only the elements that are truthy from the filter function
+            return _.filter(arr, filter);
+        }
+
+        if (_.isRegExp(filter)) {
+            return _.filter(arr, function (elem) {
+                return elem.match(filter);
+            });
+        }
     };
 };
 
@@ -30,7 +38,13 @@ map = function (filter) {
     return function (arr, func) {
         // Only map elements that are truthy from the filter function
         return _.map(_.cloneDeep(arr), function (elem) {
-            return filter(elem) ? func(elem) : elem;
+            if (_.isFunction(filter)) {
+                return filter(elem) ? func(elem) : elem;
+            }
+
+            if (_.isRegExp(filter)) {
+                return elem.match(filter) ? func(elem) : elem;
+            }
         });
     };
 };

--- a/test/testFilterLens.js
+++ b/test/testFilterLens.js
@@ -18,12 +18,18 @@ describe('FilterLens', function () {
     });
 
     describe('#get', function () {
-        it('should get the even elements', function () {
+        it('should get the even elements with a filter function', function () {
             var lens = new FilterLens(function (elem) {
                 return (elem % 2 === 0);
             });
 
             utils.testArrayEquals(lens.view([1, 2, 3, 4, 5, 6]).get(), [2, 4, 6]);
+        });
+
+        it('should get the alpha elements with a filter regex', function () {
+            var lens = new FilterLens(/^[a-zA-Z]*$/);
+
+            utils.testArrayEquals(lens.view(['abc', 'abD', 'a8b', '889']).get(), ['abc', 'abD']);
         });
     });
 
@@ -36,6 +42,17 @@ describe('FilterLens', function () {
             utils.testArrayEquals(
                 lens.view([1, 2, 3, 4, 5, 6]).map(function (elem) { return elem * 2; }),
                 [1, 4, 3, 8, 5, 12]
+            );
+        });
+
+        it('should map only the alpha elements with a filter regex', function () {
+            var lens = new FilterLens(/^[a-zA-Z]*$/);
+
+            utils.testArrayEquals(
+                lens.view(['abc', 'abD', 'a8b', '889']).map(function (str) {
+                    return str.toUpperCase();
+                }),
+                ['ABC', 'ABD', 'a8b', '889']
             );
         });
     });


### PR DESCRIPTION
Just what it says. Fixes #17.