### PR TITLE
Pluck extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+after_success:
+- istanbul cover ./node_modules/.bin/_mocha && ./node_modules/.bin/istanbul-coveralls

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <img src="NanoscopeLogo.png" width="400px"></img>
 
-<img src="https://travis-ci.org/5outh/nanoscope.svg?branch=master"></img>
-
-[![Coverage Status](https://coveralls.io/repos/5outh/nanoscope/badge.svg?branch=pluck-extensions)](https://coveralls.io/r/5outh/nanoscope?branch=pluck-extensions)
+<img src="https://travis-ci.org/5outh/nanoscope.svg?branch=master"></img> [![Coverage Status](https://coveralls.io/repos/5outh/nanoscope/badge.svg?branch=pluck-extensions)](https://coveralls.io/r/5outh/nanoscope?branch=pluck-extensions)
 
 ## A Lens Library for Javascript
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <img src="NanoscopeLogo.png" width="400px"></img>
 
 <img src="https://travis-ci.org/5outh/nanoscope.svg?branch=master"></img>
+
+[![Coverage Status](https://coveralls.io/repos/5outh/nanoscope/badge.svg?branch=pluck-extensions)](https://coveralls.io/r/5outh/nanoscope?branch=pluck-extensions)
+
 ## A Lens Library for Javascript
 
 Installation is easy:

--- a/package.json
+++ b/package.json
@@ -28,11 +28,15 @@
   },
   "devDependencies": {
     "chai": "^1.10.0",
+    "coveralls": "^2.11.2",
     "gulp": "^3.8.10",
     "gulp-mocha": "^2.0.0",
     "gulp-watch": "^3.0.0",
     "ink-docstrap": "^0.4.12",
+    "istanbul": "^0.3.5",
+    "istanbul-coveralls": "^1.0.1",
     "mocha": "^2.1.0",
+    "mocha-lcov-reporter": "0.0.1",
     "should": "^4.3.0"
   }
 }

--- a/src/combinator/MultiLens.js
+++ b/src/combinator/MultiLens.js
@@ -105,21 +105,21 @@ MultiLens.prototype = new Lens;
  */
 MultiLens.prototype.add = function (otherLens) {
     var lenses = this._lenses,
-        flags = this.getFlags(),
-        lensConstructor;
+        flags = this.getFlags();
 
-    if (this.getFlag('_baseCtor')) {
-        lensConstructor = this.getFlag('_baseCtor');
-        this.addFlag({ _baseCtor: lensConstructor });
-        otherLens = lensConstructor(otherLens);
+    if (otherLens instanceof Lens) {
+        flags = _.extend(flags, otherLens.getFlags());
     }
-
-    flags = _.extend(flags, otherLens.getFlags());
 
     if (_.isArray(lenses)) {
         lenses.push(otherLens);
     } else if (_.isObject(lenses)) {
         if (_.isObject(otherLens)) {
+            // Assumes each value is a Lens
+            _.forEach(_.values(otherLens), function (lens) {
+                flags = _.extend(flags, lens.getFlags());
+            });
+
             lenses = _.extend(lenses, otherLens);
         }
     }

--- a/src/object/PluckLens.js
+++ b/src/object/PluckLens.js
@@ -147,6 +147,7 @@ PluckLens.Recursive = function (plucker) {
  *
  * @param plucker
  * @returns {MultiLens}
+ * @param options
  */
 Lens.prototype.addPluck = function (plucker, options) {
     return this.add(new PluckLens(plucker, (options && options.recursive) || this.getFlag('_recursivePluck')));
@@ -157,6 +158,7 @@ Lens.prototype.addPluck = function (plucker, options) {
  *
  * @param plucker
  * @returns {Compose}
+ * @param options
  */
 Lens.prototype.composePluck = function (plucker, options) {
     return this.compose(new PluckLens(plucker, (options && options.recursive) || this.getFlag('_recursivePluck')));

--- a/test/testMultiLens.js
+++ b/test/testMultiLens.js
@@ -62,4 +62,12 @@ describe('MultiLens', function () {
             utils.testArrayEquals(objectMultiLens.map(testArr, addTen), [11, 2, 3, 4, 15]);
         });
     });
+
+    describe('#add', function () {
+        it('should add a field to the resulting object', function () {
+            var lens = objectMultiLens.add({ second: new IndexedLens(1) });
+
+            expect(lens.view(testArr).get()).to.eql({ head: 1, second: 2, last: 5 });
+        });
+    });
 });


### PR DESCRIPTION
Various fixes (pluck extensions are already in?)

Adds coveralls support and puts badge on README, and adds a test for object multi lens `add` (which was actually broken before)