### PR TITLE
Move optional to Optional.js and rename it to catch

### DIFF
--- a/src/base/Lens.js
+++ b/src/base/Lens.js
@@ -215,20 +215,4 @@ Lens.prototype.addMany = function (otherLenses) {
     return lens;
 };
 
-/**
- * Turns a Lens into an Optional Lens
- *
- * @param errorHandler
- * @returns {Optional}
- */
-Lens.prototype.optional = function (errorHandler) {
-    var Optional = require('../combinator/Optional');
-
-    if (errorHandler) {
-        this._errorHandler = errorHandler;
-    }
-
-    return new Optional(this, errorHandler);
-};
-
 module.exports = Lens;

--- a/src/combinator/Optional.js
+++ b/src/combinator/Optional.js
@@ -66,4 +66,20 @@ Optional = function (lens, errorHandler) {
 
 Optional.prototype = new Lens;
 
+// Add stuff to base Lens
+
+/**
+ * Turns a Lens into an Optional Lens, catching errors with optional error handler
+ *
+ * @param errorHandler
+ * @returns {Optional}
+ */
+Lens.prototype.catch = function (errorHandler) {
+    if (errorHandler) {
+        this._errorHandler = errorHandler;
+    }
+
+    return new Optional(this, errorHandler);
+};
+
 module.exports = Optional;

--- a/test/testNanoscope.js
+++ b/test/testNanoscope.js
@@ -43,6 +43,12 @@ describe('nanoscope', function () {
             expect(function () {
                 lens.unsafePath('a.b.c.d').get();
             }).to.throw(TypeError, 'Cannot read property \'d\' of undefined');
+
+            // Test that `catch` works as expected
+            lens.unsafePath('a.b.c.d').catch(function (err) {
+                return err.message;
+            }).get().should.equal('Cannot read property \'d\' of undefined');
+
         });
 
         it('should do the same thing as a PluckLens', function () {


### PR DESCRIPTION
Adds `catch` combinator for handling errors in unsafe lenses