### PR TITLE
Fixes 5outh/nanoscope#45, where `PathLens`' `map` modified in-place

### DIFF
--- a/src/object/PathLens.js
+++ b/src/object/PathLens.js
@@ -61,15 +61,12 @@ get = function (path, unsafe) {
  * @returns {Function}
  */
 map = function (path, unsafe) {
-    return function (obj, func) {
-        var previousObj = _.cloneDeep(obj),
-            newObj = obj,
+    return function (previousObj, func) {
+        var newObj = _.cloneDeep(previousObj),
+            obj = newObj,
             modifiedStructure = false,
             value,
             i;
-
-        console.log(path);
-        console.log(obj);
 
         if (_.isString(path)) {
             path = path.split('.');
@@ -79,7 +76,8 @@ map = function (path, unsafe) {
 
         // Only safeguard against empty object if using safe version
         if (!obj && !unsafe) {
-            obj = {};
+            newObj = {};
+            obj = newObj;
         }
 
         // Traverse the path and get the value we want

--- a/test/testPathLens.js
+++ b/test/testPathLens.js
@@ -47,6 +47,15 @@ describe('PathLens', function () {
 
             lens.map(testJS, function (attr) { return attr; }).a.b.should.not.have.property('c');
         });
+
+        it('should return a new object with modified obj.a.b', function () {
+            var _ = testLens.map(testJS, function (attr) { return attr + 'at'; });
+            testJS.a.b.should.equal('c');
+        });
+
+        it('should create object structure if necessary', function () {
+            testLens.map(undefined, function(attr) { return attr + 'at'; }).a.b.should.equal('undefinedat');
+        });
     });
 
     describe('#PathLens.Unsafe', function () {


### PR DESCRIPTION
This library is just what I needed - thanks for putting it out there! The features that I find most useful are the lenses, as opposed to the `nanoscope()` constructor. It seems that the lenses themselves are not documented? (Though the tests are quite helpful for understanding their behavior).

Just want to share in case you are interested: my use case is a frontend web app where app state is stored in one big data structure. I can send lenses to views, so that views can read the particular pieces of state that are important to them without having to know about the structure above and around those pieces. Then the views dispatch events that carry the same lenses. Event handlers can update the same bits of state without a requirement for any logic to reproduce traversals that produced view data.

By the way, I see that `PathLens`' `#set` functions use `_.cloneDeep()` for immutable updates. I understand that this guarantees that the copy will not be affected by later in-place changes to the original structure. But for my use, where I assume immutability everywhere, it would be more convenient to get shallow clones at each level that a `PathLens` traverses. That would primarily be a performance optimization - but I am also worried about a note from the Lodash documentation:

> An empty object is returned for uncloneable values such as functions, DOM nodes, Maps, Sets, and WeakMaps.

That makes it sound like I would have problems if I wanted to do something like mix vanilla javascript objects with lists or maps from Immutable.js.