### PR TITLE
Move all cloneDeep calls to clone (fixes #63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoscope",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "A Lens Library for Javascript",
   "main": "index.js",
   "scripts": {

--- a/src/array/FilterLens.js
+++ b/src/array/FilterLens.js
@@ -37,7 +37,7 @@ get = function (filter) {
 map = function (filter) {
     return function (arr, func) {
         // Only map elements that are truthy from the filter function
-        return _.map(_.cloneDeep(arr), function (elem) {
+        return _.map(_.clone(arr), function (elem) {
             if (_.isFunction(filter)) {
                 return filter(elem) ? func(elem) : elem;
             }

--- a/src/array/IndexedLens.js
+++ b/src/array/IndexedLens.js
@@ -52,7 +52,7 @@ get = function (index, unsafe) {
  */
 map = function (index, unsafe) {
     return function (arr, func) {
-        var newArr = _.cloneDeep(arr);
+        var newArr = _.clone(arr);
 
         index = utils.normalizeIndex(arr, index);
 

--- a/src/array/SliceLens.js
+++ b/src/array/SliceLens.js
@@ -45,7 +45,7 @@ map = function (i, j) {
             k;
 
         if (!_.isArray(arr)) {
-            return _.cloneDeep(arr);
+            return _.clone(arr);
         }
 
         i = utils.normalizeIndex(arr, i);

--- a/src/base/Lens.js
+++ b/src/base/Lens.js
@@ -52,7 +52,7 @@ Lens = function (get, map, flags) {
 
     // Set view from constructor
     if (self._flags._view) {
-        self._view = _.cloneDeep(self._flags._view);
+        self._view = _.clone(self._flags._view);
     }
 
     return self;

--- a/src/combinator/DisjunctiveLens.js
+++ b/src/combinator/DisjunctiveLens.js
@@ -48,6 +48,7 @@ map = function (lensA, lensB) {
             gotten = lensA.get(obj);
 
             if (_.isNull(gotten) || _.isUndefined(gotten)) {
+
                 return lensB.map(obj, func);
             }
 

--- a/src/combinator/MultiLens.js
+++ b/src/combinator/MultiLens.js
@@ -34,7 +34,7 @@ get = function (lenses) {
 
 map = function (lenses) {
     return function (obj, func) {
-        var newObj = _.cloneDeep(obj);
+        var newObj = _.clone(obj);
 
         if (_.isArray(lenses)) {
             _.forEach(lenses, function (lens) {

--- a/src/object/PathLens.js
+++ b/src/object/PathLens.js
@@ -62,7 +62,7 @@ get = function (path, unsafe) {
  */
 map = function (path, unsafe) {
     return function (previousObj, func) {
-        var newObj = _.cloneDeep(previousObj),
+        var newObj = _.assign(previousObj),
             obj = newObj,
             modifiedStructure = false,
             value,
@@ -85,8 +85,12 @@ map = function (path, unsafe) {
 
             // Only safeguard if not unsafe
             if (!(_.isObject(obj[path[i]])) && !unsafe) {
+                value = func(obj[path[i]])
+
+                if (value == null || (_.isNumber(value) && isNaN(value))) {
+                    return _.clone(previousObj);
+                }
                 obj[path[i]] = {};
-                modifiedStructure = true;
             }
 
             obj = obj[path[i]];
@@ -95,20 +99,8 @@ map = function (path, unsafe) {
         // Set the value we care about
         obj[path[i]] = func(obj[path[i]]);
 
-        value = obj[path[i]];
-
-        // If the value doesn't exist and we're not setting anything, return a clone of the previous object
-        // This prevents turning, for example, {} into { a: { b : { ... z: undefined } ... } }
-        // NOTE: == null catches null OR undefined values. This is on purpose.
-        if (
-            (value == null || (_.isNumber(value) && isNaN(value)))
-            && modifiedStructure
-        ) {
-            return _.cloneDeep(previousObj);
-        }
-
         // Return a clone of the modified object
-        return _.cloneDeep(newObj);
+        return _.clone(newObj);
     };
 };
 

--- a/src/object/PluckLens.js
+++ b/src/object/PluckLens.js
@@ -73,7 +73,7 @@ map = function (plucker, recursive, object) {
     return function (viewedObject, func) {
 
         if (_.isUndefined(object)) {
-            object = _.cloneDeep(viewedObject);
+            object = _.clone(viewedObject);
         }
 
         _.forEach(_.keys(viewedObject), function (property) {

--- a/test/testPathLens.js
+++ b/test/testPathLens.js
@@ -33,7 +33,7 @@ describe('PathLens', function () {
         it('should add a property even if it isnt there', function () {
             var lens = new PathLens('a.b.c.d.e.f');
 
-            lens.set(testJS, 'hello').a.b.c.d.e.f.should.equal('hello');
+            lens.set({a : { b: 'c' } }, 'hello').a.b.c.d.e.f.should.equal('hello');
         });
     });
 
@@ -45,11 +45,11 @@ describe('PathLens', function () {
         it('should not modify a deeply nested value if it doesnt exist', function () {
             var lens = new PathLens('a.b.c.d.e.f');
 
-            lens.map(testJS, function (attr) { return attr; }).a.b.should.not.have.property('c');
+            lens.map({a : { b: 'c' } }, function (attr) { return attr; }).a.b.should.not.have.property('c');
         });
 
         it('should return a new object with modified obj.a.b', function () {
-            var _ = testLens.map(testJS, function (attr) { return attr + 'at'; });
+            var _ = testLens.map({ a : { b : 'c' } }, function (attr) { return attr + 'at'; });
             testJS.a.b.should.equal('c');
         });
 


### PR DESCRIPTION
Immutable.js values aside, this prevents deep cloning of objects in Nanoscope. Definitely breaks some things, so this will have a version update.